### PR TITLE
Support for unconfigured tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
     <testng.omexmlDirectory></testng.omexmlDirectory>
     <testng.configDirectory></testng.configDirectory>
     <testng.configSuffix></testng.configSuffix>
+    <testng.allow-missing></testng.allow-missing>
     <testng.multiplier></testng.multiplier>
     <lurawave.license></lurawave.license>
     <testng.in-memory></testng.in-memory>
@@ -285,6 +286,7 @@
             <testng.omexmlDirectory>${testng.omexmlDirectory}</testng.omexmlDirectory>
             <testng.configDirectory>${testng.configDirectory}</testng.configDirectory>
             <testng.configSuffix>${testng.configSuffix}</testng.configSuffix>
+            <testng.allow-missing>${testng.allow-missing}</testng.allow-missing>
             <testng.multiplier>${testng.multiplier}</testng.multiplier>
             <lurawave.license>${lurawave.license}</lurawave.license>
             <testng.in-memory>${testng.in-memory}</testng.in-memory>

--- a/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
+++ b/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
@@ -268,32 +268,31 @@ public class FormatReaderTestFactory {
 
     // create test class instances
     System.out.println("Building list of tests...");
-    Object[] tests = new Object[files.size()];
-    for (int i=0; i<tests.length; i++) {
-      String id = (String) files.get(i);
+    List<Object> tests = new ArrayList<>();
+    for (String id : files) {
       try {
         boolean found = true;
         if (FormatReaderTest.configTree.get(id) == null) {
           found = false;
           if (allowMissing) {
-            LOGGER.warn("{} not configured.", id);
+            LOGGER.warn("{} not configured (skipping).", id);
           }
           else {
             LOGGER.error("{} not configured.", id);
           }
         }
         if (found || !allowMissing) {
-          tests[i] = new FormatReaderTest(id, multiplier, inMemory);
+          tests.add(new FormatReaderTest(id, multiplier, inMemory));
         }
       }
       catch (Exception e) {
         LOGGER.warn("", e);
       }
     }
-    if (tests.length == 1) System.out.println("Ready to test " + files.get(0));
-    else System.out.println("Ready to test " + tests.length + " files");
+    if (tests.size() == 1) System.out.println("Ready to test " + files.get(0));
+    else System.out.println("Ready to test " + tests.size() + " files");
 
-    return tests;
+    return tests.toArray(new Object[tests.size()]);
   }
 
 }

--- a/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
+++ b/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
@@ -252,14 +252,34 @@ public class FormatReaderTestFactory {
       }
     }
     if (!failingIds.isEmpty()) {
-      String msg = String.format("setId failed on %s", failingIds);
       if (!allowMissing) {
+        String msg = String.format("setId failed on %s", failingIds);
         LOGGER.error(msg);
         throw new RuntimeException(msg);
       }
       else {
-       msg += " (skipping)";
-       LOGGER.warn(msg);
+        for (String id : failingIds) {
+          boolean found = false;
+          try {
+            if (FormatReaderTest.configTree.get(id) != null) {
+              found = true;
+              }
+            }
+          catch (Exception e) {
+            LOGGER.warn("", e);
+          }
+          if (found) {
+            // setId failed and configuration present
+            String msg = String.format("setId failed on %s", id);
+            LOGGER.error(msg);
+            throw new RuntimeException(msg);
+          }
+          else {
+            // setId failed and configuration missing
+            String msg = String.format("setId failed on %s (skipping)", id);
+            LOGGER.warn(msg);
+          }
+        }
       }
     }
     files = new ArrayList<String>();

--- a/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
+++ b/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
@@ -162,6 +162,12 @@ public class FormatReaderTestFactory {
       configSuffix = "";
     }
 
+    // detect whether or not to ignore missing configuration
+    final String allowMissingProp = "testng.allow-missing";
+    String allowMissingValue = getProperty(allowMissingProp);
+    boolean allowMissing = Boolean.parseBoolean(allowMissingValue);
+    LOGGER.info("testng.allow-missing = {}", allowMissing);
+
     // display local information
     LOGGER.info("user.language = {}", System.getProperty("user.language"));
     LOGGER.info("user.country = {}", System.getProperty("user.country"));
@@ -266,14 +272,23 @@ public class FormatReaderTestFactory {
     for (int i=0; i<tests.length; i++) {
       String id = (String) files.get(i);
       try {
+        boolean found = true;
         if (FormatReaderTest.configTree.get(id) == null) {
-          LOGGER.error("{} not configured.", id);
+          found = false;
+          if (allowMissing) {
+            LOGGER.warn("{} not configured.", id);
+          }
+          else {
+            LOGGER.error("{} not configured.", id);
+          }
+        }
+        if (found || !allowMissing) {
+          tests[i] = new FormatReaderTest(id, multiplier, inMemory);
         }
       }
       catch (Exception e) {
         LOGGER.warn("", e);
       }
-      tests[i] = new FormatReaderTest(id, multiplier, inMemory);
     }
     if (tests.length == 1) System.out.println("Ready to test " + files.get(0));
     else System.out.println("Ready to test " + tests.length + " files");

--- a/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
+++ b/src/main/java/loci/tests/testng/FormatReaderTestFactory.java
@@ -253,8 +253,14 @@ public class FormatReaderTestFactory {
     }
     if (!failingIds.isEmpty()) {
       String msg = String.format("setId failed on %s", failingIds);
-      LOGGER.error(msg);
-      throw new RuntimeException(msg);
+      if (!allowMissing) {
+        LOGGER.error(msg);
+        throw new RuntimeException(msg);
+      }
+      else {
+       msg += " (skipping)";
+       LOGGER.warn(msg);
+      }
     }
     files = new ArrayList<String>();
     for (String s: minimalFiles) {


### PR DESCRIPTION
This picks the four changes from `east`, and is otherwise the same as https://github.com/openmicroscopy/bioformats/pull/3140 but for the decoupled repository (minus the `ant` logic).

Testing: Check travis and appveyor are green.  This repository isn't used for the full repo test yet, so there's nothing else to check at this point (but will be enabled soon after pyramids are done).