### PR TITLE
build: Never run upgrade checker when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,7 @@
             <testng.multiplier>${testng.multiplier}</testng.multiplier>
             <lurawave.license>${lurawave.license}</lurawave.license>
             <testng.in-memory>${testng.in-memory}</testng.in-memory>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
           </systemPropertyVariables>
           <argLine>-Xmx${testng.memory} -Duser.language=${user.language} -Duser.country=${user.country}</argLine>
           <suiteXmlFiles>


### PR DESCRIPTION
This results in unnecessary hits and biased statistics.  Add `bioformats_can_do_upgrade_check=false` to all test invocations.

See: https://github.com/openmicroscopy/bioformats/pull/3142

Testing: check CI builds are green.